### PR TITLE
Avoid converting a nil body to "null" string

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cm_quiz (0.0.4)
+    cm_quiz (0.0.5)
       httparty (~> 0.15.6)
       rspec (~> 3.6)
       thor (~> 0.19.4)
@@ -16,7 +16,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     hashdiff (0.3.6)
-    httparty (0.15.6)
+    httparty (0.15.7)
       multi_xml (>= 0.5.2)
     method_source (0.8.2)
     multi_xml (0.6.0)
@@ -25,19 +25,19 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (3.0.0)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-mocks (3.6.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     safe_yaml (1.0.4)
     slop (3.6.0)
     thor (0.19.4)
@@ -55,4 +55,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/lib/cm_quiz/project_api.rb
+++ b/lib/cm_quiz/project_api.rb
@@ -21,7 +21,7 @@ module CmQuiz
       url = @endpoint + path
 
       query = options[:query]
-      body = options[:body].to_json
+      body = options[:body]&.to_json
       headers = { 'Content-Type' => 'application/json' }.merge(options[:headers] || {})
 
       http_options = {

--- a/lib/cm_quiz/project_api.rb
+++ b/lib/cm_quiz/project_api.rb
@@ -21,7 +21,7 @@ module CmQuiz
       url = @endpoint + path
 
       query = options[:query]
-      body = options[:body]&.to_json
+      body = options[:body] ? options[:body].to_json : options[:body]
       headers = { 'Content-Type' => 'application/json' }.merge(options[:headers] || {})
 
       http_options = {


### PR DESCRIPTION
Google App Engine doesn't like an HTTP body to be present on GET or DELETE requests. For those requests, it immediately returns a 400 error without a detailed explanation. This fix allows cm-quiz to successfully complete against an app hosted on App Engine.