### PR TITLE
Update assertion of DeleteIdea endpoint

### DIFF
--- a/lib/cm_quiz/review/delete_idea.rb
+++ b/lib/cm_quiz/review/delete_idea.rb
@@ -21,7 +21,8 @@ module CmQuiz
 
         res = send_get_ideas_request(jwt: jwt)
         res_hash = JSON.parse(res.body)
-        expect(res_hash.size).to eq(0)
+        idea = res_hash.find { |item| item['id'] == idea_id }
+        expect(idea).to be_nil
       end
 
       private

--- a/lib/cm_quiz/review_helper.rb
+++ b/lib/cm_quiz/review_helper.rb
@@ -14,6 +14,10 @@ module CmQuiz
       RSpec::Matchers::BuiltIn::Be.new
     end
 
+    def be_nil
+      RSpec::Matchers::BuiltIn::BeNil.new
+    end
+
     def be_within(delta)
       RSpec::Matchers::BuiltIn::BeWithin.new(delta)
     end


### PR DESCRIPTION
Solves https://github.com/codementordev/cm-quiz/issues/5

In the old way, **if some ideas are already there in the database**, checking correctness of deleting an idea by checking equality of the size of returned ideas from GetIdeas endpoint to be ZERO, i.e. the **DeleteIdea endpoint test will always fail**, even if the idea is properly deleted.

This PR updates the assertion by ensuring the deleted idea does not exist in the resulting array of ideas anymore.

It also cleans up any idea records after completion of `create/get/update` idea tests that were created during those tests.